### PR TITLE
Fix: make change on how to show info from pay method

### DIFF
--- a/components/ContractContent.tsx
+++ b/components/ContractContent.tsx
@@ -590,17 +590,46 @@ export default function ContractContent({ contractData }: ContractContentProps) 
                   <strong>IVA</strong>.
                 </p>
 
-                {(content.tipoPago === "parcialidades" || content.tipoPago === "otro") && content.condicionesPago && (
-                  <p>
-                    <strong>Condiciones de pago:</strong>{" "}
-                    {content.condicionesPago}
-                  </p>
+                {content.tipoPago === "una_exhibicion" ? (
+                  <>
+                    <p>
+                      <strong>Forma de pago:</strong> Pago en una sola exhibición
+                    </p>
+                    <p>
+                      <strong>Método de pago:</strong>{" "}
+                      {content.formaPago || "[MÉTODO DE PAGO]"}
+                    </p>
+                  </>
+                ) : content.tipoPago === "parcialidades" ? (
+                  <>
+                    <p>
+                      <strong>Forma de pago:</strong> Pago en parcialidades
+                    </p>
+                    {content.condicionesPago && (
+                      <p>
+                        <strong>Condiciones de pago:</strong>{" "}
+                        {content.condicionesPago}
+                      </p>
+                    )}
+                    <p>
+                      <strong>Método de pago:</strong>{" "}
+                      {content.formaPago || "[MÉTODO DE PAGO]"}
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    {content.tipoPago === "otro" && content.condicionesPago && (
+                      <p>
+                        <strong>Condiciones de pago:</strong>{" "}
+                        {content.condicionesPago}
+                      </p>
+                    )}
+                    <p>
+                      <strong>Método de pago:</strong>{" "}
+                      {content.formaPago || "[MÉTODO DE PAGO]"}
+                    </p>
+                  </>
                 )}
-
-                <p>
-                  <strong>Forma de pago:</strong>{" "}
-                  {content.formaPago || "[FORMA DE PAGO]"}
-                </p>
 
                 {(content.banco ||
                   content.titularCuenta ||

--- a/components/ContractPDFGenerator.tsx
+++ b/components/ContractPDFGenerator.tsx
@@ -387,16 +387,33 @@ export function generateContractPDF(
 
   // Condiciones de pago según el tipo seleccionado
   const tipoPago = content.tipoPago || "una_exhibicion";
+  const metodoPagoText = content.formaPago || "[MÉTODO DE PAGO]";
   
   if (tipoPago === "una_exhibicion") {
-    // Pago en una sola exhibición - mantener el formato original
-    const formaPagoText = content.formaPago || "[FORMA DE PAGO]";
-    addText(`**Forma de pago:** ${formaPagoText}`, 10, false, "justify");
+    // Pago en una sola exhibición - mostrar forma de pago y método de pago
+    addText(`**Forma de pago:** Pago en una sola exhibición`, 10, false, "justify");
     addSpace(3);
-  } else if (tipoPago === "parcialidades" || tipoPago === "otro") {
-    // Pago en parcialidades u otro - agregar las condiciones específicas
+    addText(`**Método de pago:** ${metodoPagoText}`, 10, false, "justify");
+    addSpace(3);
+  } else if (tipoPago === "parcialidades") {
+    // Pago en parcialidades - mostrar forma de pago, condiciones y método de pago
+    addText(`**Forma de pago:** Pago en parcialidades`, 10, false, "justify");
+    addSpace(3);
+    
     const condicionesPago = content.condicionesPago || "[CONDICIONES DE PAGO]";
-    const formaPagoText = content.formaPago || "[FORMA DE PAGO]";
+    addText(
+      `**Condiciones de pago:** ${condicionesPago}`,
+      10,
+      false,
+      "justify",
+    );
+    addSpace(3);
+    
+    addText(`**Método de pago:** ${metodoPagoText}`, 10, false, "justify");
+    addSpace(3);
+  } else if (tipoPago === "otro") {
+    // Otro tipo de pago - solo condiciones de pago y método de pago (sin Forma de pago)
+    const condicionesPago = content.condicionesPago || "[CONDICIONES DE PAGO]";
     
     addText(
       `**Condiciones de pago:** ${condicionesPago}`,
@@ -406,7 +423,7 @@ export function generateContractPDF(
     );
     addSpace(3);
     
-    addText(`**Forma de pago:** ${formaPagoText}`, 10, false, "justify");
+    addText(`**Método de pago:** ${metodoPagoText}`, 10, false, "justify");
     addSpace(3);
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update contract content and PDF to separate Forma de pago (one-time or installments) from Método de pago and conditionally show Condiciones de pago.
> 
> - **Contract payment display**:
>   - `components/ContractContent.tsx`:
>     - Show `Forma de pago` as fixed text for `una_exhibicion` ("Pago en una sola exhibición") and `parcialidades` ("Pago en parcialidades").
>     - Always show `Método de pago` using `content.formaPago` or `[MÉTODO DE PAGO]`.
>     - Show `Condiciones de pago` only when `parcialidades` or when `tipoPago === "otro"` and `condicionesPago` exists.
>     - Remove previous generic `Forma de pago: [FORMA DE PAGO]` line.
>   - `components/ContractPDFGenerator.tsx`:
>     - Mirror the above logic in PDF output; introduce `metodoPagoText` and default `[CONDICIONES DE PAGO]` where applicable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2d6097897b2474fe2de6a5964404868f1df5594. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->